### PR TITLE
Sonar renaming / Eclipse config ignore / TC build status / build process fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ rel.sh
 start.sh
 stop.sh
 servers
+**/.project
+**/.classpath
+**/.settings
+repository/lib

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
               <plugin>
                 <groupId>org.jetbrains.teamcity</groupId>
                 <artifactId>teamcity-sdk-maven-plugin</artifactId>
-                <version>0.2</version>
+                <version>0.4</version>
                 <inherited>false</inherited>
               </plugin>
           </plugins>

--- a/readme.md
+++ b/readme.md
@@ -18,14 +18,18 @@ http://teamcity.jetbrains.com/repository/download/TeamCityPluginsByJetBrains_Tea
 
  ## 2. Building sources
 
-
- Run the following command in the root of the checked out repository:
+ From the TeamCity build targeted version bundle, copy into `repository/lib` the JAR file(s) from `webapps/ROOT/WEB-INF/lib/`:
  
-    `mvn clean package`
+ - `server-tools.jar`
+ - `common-tools.jar` (if exist, useless since TeamCity v2019.x)
+
+ And run the following command in the root of the checked out repository:
+ 
+    mvn clean package
 
  ## 3. Installing
  
- Install the plugin as described in the [TeamCity documentation](http://confluence.jetbrains.com/display/TCDL/Installing+Additional+Plugins).
+ Install the plugin as described in the [TeamCity documentation](https://www.jetbrains.com/help/teamcity/installing-additional-plugins.html).
 
 
 ## 4. Key features

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 
 
-[![official JetBrains project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![official JetBrains project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Build Status](https://teamcity.jetbrains.com/app/rest/builds/buildType:TeamCityPluginsByJetBrains_TeamCitySonarQubePlugin_Develop/statusIcon.png)](https://teamcity.jetbrains.com/viewType.html?buildTypeId=TeamCityPluginsByJetBrains_TeamCitySonarQubePlugin_Develop)
 
 
  TeamCity SonarQube plugin

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>sonar-plugin</artifactId>
@@ -16,22 +16,6 @@
                 <artifactId>maven-install-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>org.jetbrains.teamcity:common-tools</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>install-file</goal>
-                        </goals>
-                        <configuration>
-                            <groupId>org.jetbrains.teamcity</groupId>
-                            <artifactId>common-tools</artifactId>
-                            <version>2017.1</version>
-                            <packaging>jar</packaging>
-                            <file>${basedir}/lib/common-tools.jar</file>
-                            <createChecksum>true</createChecksum>
-                            <generatePom>true</generatePom>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>org.jetbrains.teamcity:server-tools</id>
                         <phase>validate</phase>
                         <goals>
@@ -40,7 +24,7 @@
                         <configuration>
                             <groupId>org.jetbrains.teamcity</groupId>
                             <artifactId>server-tools</artifactId>
-                            <version>2017.1</version>
+                            <version>${teamcity-version}</version>
                             <packaging>jar</packaging>
                             <file>${basedir}/lib/server-tools.jar</file>
                             <createChecksum>true</createChecksum>
@@ -51,4 +35,40 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>tc-previous-2019</id>
+            <activation>
+                <file>
+                    <exists>${basedir}/lib/common-tools.jar</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>org.jetbrains.teamcity:common-tools</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>install-file</goal>
+                                </goals>
+                                <configuration>
+                                    <groupId>org.jetbrains.teamcity</groupId>
+                                    <artifactId>common-tools</artifactId>
+                                    <version>${teamcity-version}</version>
+                                    <packaging>jar</packaging>
+                                    <file>${basedir}/lib/common-tools.jar</file>
+                                    <createChecksum>true</createChecksum>
+                                    <generatePom>true</generatePom>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/sonar-plugin-server/pom.xml
+++ b/sonar-plugin-server/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <build>
         <pluginManagement>
@@ -91,14 +91,26 @@
         <dependency>
             <groupId>org.jetbrains.teamcity</groupId>
             <artifactId>server-tools</artifactId>
-            <version>2017.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jetbrains.teamcity</groupId>
-            <artifactId>common-tools</artifactId>
-            <version>2017.1</version>
+            <version>${teamcity-version}</version>
         </dependency>
 
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>tc-previous-2019</id>
+            <activation>
+                <file>
+                    <exists>${basedir}/../repository/lib/common-tools.jar</exists>
+                </file>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jetbrains.teamcity</groupId>
+                    <artifactId>common-tools</artifactId>
+                    <version>${teamcity-version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/sonar-plugin-server/src/main/resources/buildServerResources/SQSViewRunnerCommon.jsp
+++ b/sonar-plugin-server/src/main/resources/buildServerResources/SQSViewRunnerCommon.jsp
@@ -15,7 +15,7 @@
 </div>
 
 <div class="parameter">
-    Sonar Server ID: <strong><props:displayValue name="sonarServer"/></strong>
+    SonarQube Server ID: <strong><props:displayValue name="sonarServer"/></strong>
 </div>
 
 <div class="parameter">

--- a/sonar-plugin-server/src/main/resources/buildServerResources/buildSummary.jsp
+++ b/sonar-plugin-server/src/main/resources/buildServerResources/buildSummary.jsp
@@ -4,7 +4,7 @@
 <c:if test="${not empty sonar_url}">
     <tr><td></td>
         <td class="st">
-            <a href="${util:escapeUrlForQuotes(sonar_url)}">View in sonar</a>
+            <a href="${util:escapeUrlForQuotes(sonar_url)}">View in SonarQube</a>
         </td>
     </tr>
 </c:if>


### PR DESCRIPTION
Some forgetfulness about [Sonar Becomes The SonarQube Platform](https://blog.sonarsource.com/sonar-becomes-the-sonarqube-platform/). Very valuable PR 😄 !!!

---

BTW, some Eclipse config ignore (not only IntelliJ in the life ^^).

---

And because badge icons are awesome feature, TeamCity build added ! (When #69 done, I hope this plugin could be installed on https://teamcity.jetbrains.com, to have PR analysis on [SonarCloud](https://sonarcloud.io/) 😀).

---- 

Fix #55 by explain which JARs to copy, and install it optionnally depending content (`common-tools` depending if present, related to TeamCity version)

----

**NB**: Promised: Next time one PR by item 😄 (I was in mode: fix quick things)